### PR TITLE
Fix #12: windows版のショートカットキーを追加

### DIFF
--- a/src/components/quest/QuestChallenge.tsx
+++ b/src/components/quest/QuestChallenge.tsx
@@ -1,3 +1,5 @@
+import { withWindowsShortcuts } from '@/lib/shortcut-display';
+
 interface QuestChallengeProps {
   challenge: string;
 }
@@ -10,7 +12,7 @@ export default function QuestChallenge({ challenge }: QuestChallengeProps) {
           &#x1F3AF; チャレンジ
         </h2>
         <p className="text-lg text-amber-900 leading-relaxed">
-          {challenge}
+          {withWindowsShortcuts(challenge)}
         </p>
       </div>
     </div>

--- a/src/components/quest/QuestCheckQuestions.tsx
+++ b/src/components/quest/QuestCheckQuestions.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import type { CheckQuestion } from '@/types';
+import { withWindowsShortcuts } from '@/lib/shortcut-display';
 
 interface QuestCheckQuestionsProps {
   questions: CheckQuestion[];
@@ -66,7 +67,7 @@ export default function QuestCheckQuestions({
             <div key={qIndex} className="space-y-3">
               {/* Question */}
               <h3 className="font-medium text-text-primary">
-                Q{qIndex + 1}. {q.question}
+                Q{qIndex + 1}. {withWindowsShortcuts(q.question)}
               </h3>
 
               {/* Options */}
@@ -112,7 +113,9 @@ export default function QuestCheckQuestions({
                         <span className="flex-shrink-0 w-6 h-6 rounded-full border border-current flex items-center justify-center text-xs font-medium">
                           {String.fromCharCode(65 + oIndex)}
                         </span>
-                        <span className="text-sm">{option}</span>
+                        <span className="text-sm">
+                          {withWindowsShortcuts(option)}
+                        </span>
 
                         {/* Correct/incorrect icon */}
                         {hasAnswered && isSelected && answer.isCorrect && (
@@ -163,7 +166,7 @@ export default function QuestCheckQuestions({
                   <span className="font-medium">
                     {answer.isCorrect ? '正解!' : '不正解...'}
                   </span>{' '}
-                  {q.explanation}
+                  {withWindowsShortcuts(q.explanation)}
                 </div>
               )}
             </div>

--- a/src/components/quest/QuestHeader.tsx
+++ b/src/components/quest/QuestHeader.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import type { Quest } from '@/types';
+import { withWindowsShortcuts } from '@/lib/shortcut-display';
 
 interface QuestHeaderProps {
   quest: Quest;
@@ -99,7 +100,7 @@ export default function QuestHeader({ quest, dayTitle }: QuestHeaderProps) {
       {/* Description */}
       {quest.description && (
         <p className="mt-4 text-text-secondary leading-relaxed">
-          {quest.description}
+          {withWindowsShortcuts(quest.description)}
         </p>
       )}
     </div>

--- a/src/components/quest/QuestHints.tsx
+++ b/src/components/quest/QuestHints.tsx
@@ -1,4 +1,5 @@
 import ExpandableSection from '@/components/ui/ExpandableSection';
+import { withWindowsShortcuts } from '@/lib/shortcut-display';
 
 interface QuestHintsProps {
   hints: string[];
@@ -21,7 +22,9 @@ export default function QuestHints({ hints }: QuestHintsProps) {
             defaultOpen={false}
             className="bg-yellow-50 border-yellow-200"
           >
-            <p className="text-text-secondary leading-relaxed">{hint}</p>
+            <p className="text-text-secondary leading-relaxed">
+              {withWindowsShortcuts(hint)}
+            </p>
           </ExpandableSection>
         ))}
       </div>

--- a/src/components/quest/StepContent.tsx
+++ b/src/components/quest/StepContent.tsx
@@ -1,3 +1,5 @@
+import { withWindowsShortcuts } from '@/lib/shortcut-display';
+
 interface StepContentProps {
   content: string;
 }
@@ -44,8 +46,9 @@ function parseLine(line: string, key: number): React.ReactNode {
 }
 
 export default function StepContent({ content }: StepContentProps) {
+  const normalizedContent = withWindowsShortcuts(content);
   // Split into paragraphs by double newline
-  const paragraphs = content.split('\n\n');
+  const paragraphs = normalizedContent.split('\n\n');
 
   return (
     <>

--- a/src/lib/shortcut-display.ts
+++ b/src/lib/shortcut-display.ts
@@ -1,0 +1,25 @@
+const WINDOWS_NOTE = 'Windowsの場合は';
+
+function appendWindowsShortcut(
+  text: string,
+  sourceLabel: 'Cmd' | 'Option',
+  targetLabel: 'Ctrl' | 'Alt'
+): string {
+  const regex = new RegExp(
+    `${sourceLabel}\\+([A-Za-z0-9\`,]+(?:\\+[A-Za-z0-9\`,]+)*)`,
+    'g'
+  );
+
+  return text.replace(regex, (full, keys, offset, original) => {
+    const tail = original.slice(offset + full.length, offset + full.length + 40);
+    if (tail.includes(WINDOWS_NOTE) || tail.includes(targetLabel)) {
+      return full;
+    }
+    return `${full}（${WINDOWS_NOTE}${targetLabel}+${keys}）`;
+  });
+}
+
+export function withWindowsShortcuts(text: string): string {
+  const withCtrl = appendWindowsShortcut(text, 'Cmd', 'Ctrl');
+  return appendWindowsShortcut(withCtrl, 'Option', 'Alt');
+}


### PR DESCRIPTION
## 概要
既存のmacOSのショートカットの隣にwindows用のショートカットキーを追加しました。

## 変更内容
* 既存のショートカットキーの隣に、Windows環境向けの表記を拡充
* **例:** `Cmd+K`（Windowsの場合は`Ctrl+K`）

## 関連Issue
Fixes #